### PR TITLE
Remove field labels from GPT_RECORD output

### DIFF
--- a/src/core/postprocess.js
+++ b/src/core/postprocess.js
@@ -62,7 +62,7 @@ var PostProcessor = (function() {
     for (var i = 0; i < fields.length; i++) {
       var field = fields[i];
       var coerced = coerceField(record[field.key], field.type);
-      rows.push([field.key + ': ' + formatCoercedValue(coerced, field.type)]);
+      rows.push([formatCoercedValue(coerced, field.type)]);
     }
 
     return rows.length ? rows : [['(no data)']];


### PR DESCRIPTION
## Summary
- update record post-processing to avoid prefixing field names when returning values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67184a5888333abe79ac1f7f22729